### PR TITLE
Add FastAPI backend and React frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # SuperWiseChat
-A chat application powered by LLMs
+
+This repo contains a minimal chat application using FastAPI for the backend and React for the frontend. Google Sign-In is used for authentication and MongoDB stores chat messages.
+
+## Backend
+See [backend/README.md](backend/README.md) for setup instructions.
+
+## Frontend
+See [frontend/README.md](frontend/README.md) for setup instructions.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# FastAPI Backend
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the development server:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Set `GOOGLE_CLIENT_ID` for Google sign in verification and `MONGO_URI` for the MongoDB connection.

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,11 @@
+import os
+import motor.motor_asyncio
+
+MONGO_URI = os.getenv("MONGO_URI", "mongodb://localhost:27017")
+DB_NAME = os.getenv("DB_NAME", "chatdb")
+
+_client = motor.motor_asyncio.AsyncIOMotorClient(MONGO_URI)
+_db = _client[DB_NAME]
+
+async def get_messages_collection():
+    return _db["messages"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,54 @@
+from fastapi import FastAPI, Depends, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.security import OAuth2AuthorizationCodeBearer
+from pydantic import BaseModel
+from typing import List
+import motor.motor_asyncio
+import os
+import google.oauth2.id_token
+import google.auth.transport.requests
+
+from .db import get_messages_collection
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID", "")
+
+class Message(BaseModel):
+    user: str
+    content: str
+
+@app.get("/messages", response_model=List[Message])
+async def get_messages(collection=Depends(get_messages_collection)):
+    messages = []
+    async for m in collection.find():
+        messages.append(Message(user=m["user"], content=m["content"]))
+    return messages
+
+@app.post("/messages")
+async def post_message(msg: Message, collection=Depends(get_messages_collection)):
+    await collection.insert_one(msg.dict())
+    return {"status": "ok"}
+
+@app.post("/verify")
+async def verify_token(token: str):
+    if not GOOGLE_CLIENT_ID:
+        raise HTTPException(status_code=500, detail="Google client id not configured")
+    try:
+        request = google.auth.transport.requests.Request()
+        id_info = google.oauth2.id_token.verify_oauth2_token(token, request, GOOGLE_CLIENT_ID)
+        return {"sub": id_info.get("sub"), "email": id_info.get("email")}
+    except Exception as e:
+        raise HTTPException(status_code=401, detail="Invalid token") from e
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class Message(BaseModel):
+    user: str
+    content: str

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+motor
+google-auth
+python-dotenv

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,15 @@
+# React Frontend
+
+Install dependencies (requires Node.js):
+
+```bash
+npm install
+```
+
+Start the development server:
+
+```bash
+npm start
+```
+
+Update `YOUR_GOOGLE_CLIENT_ID` in `src/components/Login.js` with your Google OAuth client id.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "superwisechat-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "parcel public/index.html --port 3000",
+    "build": "parcel build public/index.html"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "parcel": "^2.9.3"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SuperWiseChat</title>
+    <script src="https://accounts.google.com/gsi/client" async defer></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="../src/index.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,15 @@
+import React, { useEffect, useState } from 'https://cdn.skypack.dev/react';
+import Chat from './components/Chat.js';
+import Login from './components/Login.js';
+
+export default function App() {
+  const [user, setUser] = useState(null);
+  const handleLogin = (info) => {
+    setUser(info);
+  };
+  return (
+    <div>
+      {user ? <Chat user={user} /> : <Login onLogin={handleLogin} />}
+    </div>
+  );
+}

--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'https://cdn.skypack.dev/react';
+
+export default function Chat({ user }) {
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:8000/messages')
+      .then(res => res.json())
+      .then(setMessages);
+  }, []);
+
+  const sendMessage = () => {
+    fetch('http://localhost:8000/messages', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user: user.email, content: text })
+    }).then(() => {
+      setMessages([...messages, { user: user.email, content: text }]);
+      setText('');
+    });
+  };
+
+  return (
+    <div>
+      <ul>
+        {messages.map((m, i) => (
+          <li key={i}><strong>{m.user}</strong>: {m.content}</li>
+        ))}
+      </ul>
+      <input value={text} onChange={e => setText(e.target.value)} />
+      <button onClick={sendMessage}>Send</button>
+    </div>
+  );
+}

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'https://cdn.skypack.dev/react';
+
+export default function Login({ onLogin }) {
+  useEffect(() => {
+    /* global google */
+    if (window.google) {
+      google.accounts.id.initialize({
+        client_id: 'YOUR_GOOGLE_CLIENT_ID',
+        callback: (response) => {
+          fetch('http://localhost:8000/verify', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ token: response.credential })
+          })
+            .then(res => res.json())
+            .then(data => onLogin(data))
+            .catch(console.error);
+        }
+      });
+      google.accounts.id.renderButton(
+        document.getElementById('signInDiv'),
+        { theme: 'outline', size: 'large' }
+      );
+    }
+  }, []);
+  return <div id="signInDiv"></div>;
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,5 @@
+import React from 'https://cdn.skypack.dev/react';
+import ReactDOM from 'https://cdn.skypack.dev/react-dom';
+import App from './App.js';
+
+ReactDOM.render(<App />, document.getElementById('root'));


### PR DESCRIPTION
## Summary
- set up a FastAPI backend with MongoDB
- add endpoints for messages and Google token verification
- add minimal React frontend with Google Sign-In and chat UI
- document backend and frontend setup

## Testing
- `python3 -m py_compile $(find backend -name '*.py')`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_683f95589ec083288af3dfc8f7a83c8c